### PR TITLE
docs: fix 'browser to server' build config

### DIFF
--- a/examples/browser-to-server/vite.config.js
+++ b/examples/browser-to-server/vite.config.js
@@ -1,9 +1,9 @@
 export default {
   build: {
-    target: 'es2020'
+    target: 'es2022'
   },
   optimizeDeps: {
-    esbuildOptions: { target: 'es2020', supported: { bigint: true } }
+    esbuildOptions: { target: 'es2022', supported: { bigint: true } }
   },
   server: {
     open: true


### PR DESCRIPTION
update build confog to fix this error:

`✘ [ERROR] Top-level await is not available in the configured target environment ("es2020" + 1 override)

    index.js:15:15:
      15 │   const node = await createLibp2p({
         ╵                ~~~~~

✘ [ERROR] Top-level await is not available in the configured target environment ("es2020" + 1 override)

    index.js:20:2:
      20 │   await node.start()
         ╵   ~~~~~
`