### PR TITLE
feat: Add metrics for common events

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,6 +137,7 @@
   "dependencies": {
     "@chainsafe/libp2p-noise": "^10.0.0",
     "@libp2p/interface-connection": "^3.0.2",
+    "@libp2p/interface-metrics": "^4.0.4",
     "@libp2p/interface-peer-id": "^1.0.5",
     "@libp2p/interface-stream-muxer": "^3.0.0",
     "@libp2p/interface-transport": "^2.0.0",

--- a/src/maconn.ts
+++ b/src/maconn.ts
@@ -1,4 +1,5 @@
 import type { MultiaddrConnection, MultiaddrConnectionTimeline } from '@libp2p/interface-connection'
+import type { CounterGroup } from '@libp2p/interface-metrics'
 import { logger } from '@libp2p/logger'
 import type { Multiaddr } from '@multiformats/multiaddr'
 import type { Source, Sink } from 'it-stream-types'
@@ -22,6 +23,11 @@ interface WebRTCMultiaddrConnectionInit {
    * Holds the relevant events timestamps of the connection
    */
   timeline: MultiaddrConnectionTimeline
+
+  /**
+   * Optional metrics counter group for this connection
+   */
+  metrics: CounterGroup | null
 }
 
 export class WebRTCMultiaddrConnection implements MultiaddrConnection {
@@ -39,6 +45,11 @@ export class WebRTCMultiaddrConnection implements MultiaddrConnection {
    * Holds the lifecycle times of the connection
    */
   timeline: MultiaddrConnectionTimeline;
+
+  /**
+   * Optional metrics counter group for this connection
+   */
+  metrics?: CounterGroup
 
   /**
    * The stream source, a no-op as the transport natively supports multiplexing
@@ -62,6 +73,7 @@ export class WebRTCMultiaddrConnection implements MultiaddrConnection {
     }
 
     this.timeline.close = new Date().getTime()
+    this.metrics?.increment({ close: true })
     this.peerConnection.close()
   }
 }

--- a/test/maconn.browser.spec.ts
+++ b/test/maconn.browser.spec.ts
@@ -11,6 +11,7 @@ describe('Multiaddr Connection', () => {
     const remoteAddr = multiaddr('/ip4/1.2.3.4/udp/1234/webrtc/certhash/uEiAUqV7kzvM1wI5DYDc1RbcekYVmXli_Qprlw3IkiEg6tQ')
     const maConn = new WebRTCMultiaddrConnection({
       peerConnection: peerConnection,
+      metrics: null,
       remoteAddr,
       timeline: {
         open: (new Date()).getTime()


### PR DESCRIPTION
Adds metrics for common error cases (timeoout, dtls handshake failure) and few success cases (stream open / stream close) 

Open questions:

 - [ ] The TCP implementation https://github.com/libp2p/js-libp2p-tcp/blob/b93f4c0a921923401264aa560ae259afc9430a93/src/socket-to-conn.ts#L22 has the ability to prefix individual connection events (such as for close or perhaps the muxer?). I was not certain this would be helpful in this context and omitted it here. Should we add it?
 - [ ] Testing metrics collection I'd love to see metrics collection be part of the test suite. I was thinking perhaps either a mock object or an interface which allows collecting metrics in memory (similar to the prom client) but tests can verify the calls later. 


Closes: https://github.com/libp2p/js-libp2p-webrtc/issues/64