### PR TITLE
fix: added peer connection state listener to emit closed events

### DIFF
--- a/src/maconn.ts
+++ b/src/maconn.ts
@@ -61,6 +61,8 @@ export class WebRTCMultiaddrConnection implements MultiaddrConnection {
       log.error('error closing connection', err)
     }
 
+    log.trace('closing connection')
+
     this.timeline.close = Date.now()
     this.peerConnection.close()
   }

--- a/src/maconn.ts
+++ b/src/maconn.ts
@@ -61,7 +61,7 @@ export class WebRTCMultiaddrConnection implements MultiaddrConnection {
       log.error('error closing connection', err)
     }
 
-    this.timeline.close = new Date().getTime()
+    this.timeline.close = Date.now()
     this.peerConnection.close()
   }
 }

--- a/src/peer_transport/transport.ts
+++ b/src/peer_transport/transport.ts
@@ -13,7 +13,6 @@ import { logger } from '@libp2p/logger'
 import { initiateConnection, handleIncomingStream } from './handler.js'
 import { CodeError } from '@libp2p/interfaces/errors'
 import { codes } from '../error.js'
-import { isFirefox } from './util.js'
 
 const log = logger('libp2p:webrtc:peer')
 
@@ -141,38 +140,6 @@ export class WebRTCTransport implements Transport, Startable {
           muxerFactory
         }
       )
-
-      if (isFirefox) {
-        pc.addEventListener('oniceconnectionstatechange', () => {
-          switch (pc.connectionState) {
-            case 'failed':
-            case 'disconnected':
-            case 'closed':
-              result.close().catch((err) => {
-                log.error('error closing connection', err)
-              })
-              break
-
-            default:
-              break
-          }
-        })
-      } else {
-        pc.addEventListener('onconnectionstatechange', () => {
-          switch (pc.connectionState) {
-            case 'failed':
-            case 'disconnected':
-            case 'closed':
-              result.close().catch((err) => {
-                log.error('error closing connection', err)
-              })
-              break
-
-            default:
-              break
-          }
-        })
-      }
 
       // close the stream if SDP has been exchanged successfully
       rawStream.close()

--- a/src/peer_transport/transport.ts
+++ b/src/peer_transport/transport.ts
@@ -13,6 +13,7 @@ import { logger } from '@libp2p/logger'
 import { initiateConnection, handleIncomingStream } from './handler.js'
 import { CodeError } from '@libp2p/interfaces/errors'
 import { codes } from '../error.js'
+import { isFirefox } from './util.js'
 
 const log = logger('libp2p:webrtc:peer')
 
@@ -131,7 +132,7 @@ export class WebRTCTransport implements Transport, Startable {
       const result = await options.upgrader.upgradeOutbound(
         new WebRTCMultiaddrConnection({
           peerConnection: pc,
-          timeline: { open: (new Date()).getTime() },
+          timeline: { open: Date.now() },
           remoteAddr: webrtcMultiaddr
         }),
         {
@@ -140,6 +141,38 @@ export class WebRTCTransport implements Transport, Startable {
           muxerFactory
         }
       )
+
+      if (isFirefox) {
+        pc.addEventListener('oniceconnectionstatechange', () => {
+          switch (pc.connectionState) {
+            case 'failed':
+            case 'disconnected':
+            case 'closed':
+              result.close().catch((err) => {
+                log.error('error closing connection', err)
+              })
+              break
+
+            default:
+              break
+          }
+        })
+      } else {
+        pc.addEventListener('onconnectionstatechange', () => {
+          switch (pc.connectionState) {
+            case 'failed':
+            case 'disconnected':
+            case 'closed':
+              result.close().catch((err) => {
+                log.error('error closing connection', err)
+              })
+              break
+
+            default:
+              break
+          }
+        })
+      }
 
       // close the stream if SDP has been exchanged successfully
       rawStream.close()

--- a/src/peer_transport/util.ts
+++ b/src/peer_transport/util.ts
@@ -4,7 +4,7 @@ import * as pb from './pb/index.js'
 import { detect } from 'detect-browser'
 
 const browser = detect()
-const isFirefox = ((browser != null) && browser.name === 'firefox')
+export const isFirefox = ((browser != null) && browser.name === 'firefox')
 
 interface MessageStream {
   read: () => Promise<pb.Message>

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -98,6 +98,9 @@ export class WebRTCDirectTransport implements Transport {
    * Connect to a peer using a multiaddr
    */
   async _connect (ma: Multiaddr, options: WebRTCDialOptions): Promise<Connection> {
+    const controller = new AbortController()
+    const signal = controller.signal
+
     const remotePeerString = ma.getPeerId()
     if (remotePeerString === null) {
       throw inappropriateMultiaddr("we need to have the remote's PeerId")
@@ -194,13 +197,14 @@ export class WebRTCDirectTransport implements Transport {
           maConn.close().catch((err) => {
             log.error('error closing connection', err)
           }).finally(() => {
-            peerConnection.removeEventListener(eventListeningName, () => {})
+            // Remove the event listener once the connection is closed
+            controller.abort()
           })
           break
         default:
           break
       }
-    })
+    }, { signal })
 
     // Creating the connection before completion of the noise
     // handshake ensures that the stream opening callback is set up

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -193,9 +193,10 @@ export class WebRTCDirectTransport implements Transport {
         case 'closed':
           maConn.close().catch((err) => {
             log.error('error closing connection', err)
+          }).finally(() => {
+            peerConnection.removeEventListener(eventListeningName, () => {})
           })
           break
-
         default:
           break
       }


### PR DESCRIPTION
The `RTCPeerConnection` state is not being monitored, as a result the `peer:Disconnect` event which is triggered by a `connectionEnd` event is not fired, resulting in closed connections not being properly propogated.

We can listen for disconnect events using the [RTCPeerConnection connectionstatechange event](https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/connectionstatechange_event)

Closes: https://github.com/libp2p/js-libp2p-webrtc/issues/138