### PR TITLE
fix: make it work as GiHub dependency when using Vite

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,6 +125,7 @@
   "scripts": {
     "generate": "protons src/private-to-private/pb/message.proto src/pb/message.proto",
     "build": "aegir build",
+    "prepare": "npm run build",
     "test": "aegir test -t browser",
     "test:chrome": "aegir test -t browser --cov",
     "test:firefox": "aegir test -t browser --browser firefox",


### PR DESCRIPTION
When using `@libp2p/webrtc` directly with pointing to a GitHub repository, it won't build with Vite, due to the defined `exports` in the package.json. One way to make it work is adding the build step as `prepare` script.

Steps to reproduce the issue:

    npm create vite@latest -- --template vanilla webrtcasgithubdep
    cd webrtcasgithubdep
    npm install https://github.com/libp2p/js-libp2p-webrtc
    echo "import { webRTC } from '@libp2p/webrtc'" > main.js
    npm run build

Errors with:

    [commonjs--resolver] Failed to resolve entry for package "@libp2p/webrtc". The package may have incorrect main/module/exports specified in its package.json.
error during build

With the prepare script it builds without errors.

---

There are probably better fixes and it might even be something to do on the Aegir level. I thought I open a PR as this is a good way to also try it out. Just follow those steps and then run

    npm install https://github.com/vmx/js-libp2p-webrtc#add-prepare-script
    npm run build

and you can see the it builds successfully.

Thanks @Gozala for pointing me to this solution.