### PR TITLE
fix: Update splitAddr function to correctly parse multiaddrs

### DIFF
--- a/src/private-to-private/transport.ts
+++ b/src/private-to-private/transport.ts
@@ -148,7 +148,7 @@ export class WebRTCTransport implements Transport, Startable {
 }
 
 export function splitAddr (ma: Multiaddr): { baseAddr: Multiaddr, peerId: PeerId } {
-  const addrs = ma.toString().split(WEBRTC_TRANSPORT)
+  const addrs = ma.toString().split(WEBRTC_TRANSPORT + '/')
   if (addrs.length !== 2) {
     throw new CodeError('webrtc protocol was not present in multiaddr', codes.ERR_INVALID_MULTIADDR)
   }
@@ -159,7 +159,7 @@ export function splitAddr (ma: Multiaddr): { baseAddr: Multiaddr, peerId: PeerId
 
   // look for remote peerId
   let remoteAddr = multiaddr(addrs[0])
-  const destination = multiaddr(addrs[1])
+  const destination = multiaddr('/' + addrs[1])
 
   const destinationIdString = destination.getPeerId()
   if (destinationIdString == null) {

--- a/src/private-to-private/transport.ts
+++ b/src/private-to-private/transport.ts
@@ -72,36 +72,6 @@ export class WebRTCTransport implements Transport, Startable {
     })
   }
 
-  private splitAddr (ma: Multiaddr): { baseAddr: Multiaddr, peerId: PeerId } {
-    const addrs = ma.toString().split(WEBRTC_TRANSPORT)
-    if (addrs.length !== 2) {
-      throw new CodeError('webrtc protocol was not present in multiaddr', codes.ERR_INVALID_MULTIADDR)
-    }
-
-    if (!addrs[0].includes(CIRCUIT_RELAY_TRANSPORT)) {
-      throw new CodeError('p2p-circuit protocol was not present in multiaddr', codes.ERR_INVALID_MULTIADDR)
-    }
-
-    // look for remote peerId
-    let remoteAddr = multiaddr(addrs[0])
-    const destination = multiaddr(addrs[1])
-
-    const destinationIdString = destination.getPeerId()
-    if (destinationIdString == null) {
-      throw new CodeError('destination peer id was missing', codes.ERR_INVALID_MULTIADDR)
-    }
-
-    const lastProtoInRemote = remoteAddr.protos().pop()
-    if (lastProtoInRemote === undefined) {
-      throw new CodeError('invalid multiaddr', codes.ERR_INVALID_MULTIADDR)
-    }
-    if (lastProtoInRemote.name !== 'p2p') {
-      remoteAddr = remoteAddr.encapsulate(`/p2p/${destinationIdString}`)
-    }
-
-    return { baseAddr: remoteAddr, peerId: peerIdFromString(destinationIdString) }
-  }
-
   /*
    * dial connects to a remote via the circuit relay or any other protocol
    * and proceeds to upgrade to a webrtc connection.
@@ -111,7 +81,7 @@ export class WebRTCTransport implements Transport, Startable {
   */
   async dial (ma: Multiaddr, options: DialOptions): Promise<Connection> {
     log.trace('dialing address: ', ma)
-    const { baseAddr, peerId } = this.splitAddr(ma)
+    const { baseAddr, peerId } = splitAddr(ma)
 
     if (options.signal == null) {
       const controller = new AbortController()
@@ -175,4 +145,34 @@ export class WebRTCTransport implements Transport, Startable {
       throw err
     }
   }
+}
+
+export function splitAddr (ma: Multiaddr): { baseAddr: Multiaddr, peerId: PeerId } {
+  const addrs = ma.toString().split(WEBRTC_TRANSPORT)
+  if (addrs.length !== 2) {
+    throw new CodeError('webrtc protocol was not present in multiaddr', codes.ERR_INVALID_MULTIADDR)
+  }
+
+  if (!addrs[0].includes(CIRCUIT_RELAY_TRANSPORT)) {
+    throw new CodeError('p2p-circuit protocol was not present in multiaddr', codes.ERR_INVALID_MULTIADDR)
+  }
+
+  // look for remote peerId
+  let remoteAddr = multiaddr(addrs[0])
+  const destination = multiaddr(addrs[1])
+
+  const destinationIdString = destination.getPeerId()
+  if (destinationIdString == null) {
+    throw new CodeError('destination peer id was missing', codes.ERR_INVALID_MULTIADDR)
+  }
+
+  const lastProtoInRemote = remoteAddr.protos().pop()
+  if (lastProtoInRemote === undefined) {
+    throw new CodeError('invalid multiaddr', codes.ERR_INVALID_MULTIADDR)
+  }
+  if (lastProtoInRemote.name !== 'p2p') {
+    remoteAddr = remoteAddr.encapsulate(`/p2p/${destinationIdString}`)
+  }
+
+  return { baseAddr: remoteAddr, peerId: peerIdFromString(destinationIdString) }
 }

--- a/test/peer.browser.spec.ts
+++ b/test/peer.browser.spec.ts
@@ -9,7 +9,7 @@ import { pbStream } from 'it-pb-stream'
 import Sinon from 'sinon'
 import { initiateConnection, handleIncomingStream } from '../src/private-to-private/handler'
 import { Message } from '../src/private-to-private/pb/message.js'
-import { WebRTCTransport } from '../src/private-to-private/transport'
+import { WebRTCTransport, splitAddr } from '../src/private-to-private/transport'
 
 const browser = detect()
 
@@ -106,6 +106,26 @@ describe('webrtc filter', () => {
     ]
 
     expect(transport.filter(valid)).length(1)
+  })
+})
+
+describe('webrtc splitAddr', () => {
+  it('can split a ws relay addr', async () => {
+    const ma = multiaddr('/ip4/127.0.0.1/tcp/49173/ws/p2p/12D3KooWFqpHsdZaL4NW6eVE3yjhoSDNv7HJehPZqj17kjKntAh2/p2p-circuit/webrtc/p2p/12D3KooWF2P1k8SVRL1cV1Z9aNM8EVRwbrMESyRf58ceQkaht4AF')
+
+    const { baseAddr, peerId } = splitAddr(ma)
+
+    expect(baseAddr.toString()).to.eq('/ip4/127.0.0.1/tcp/49173/ws/p2p/12D3KooWFqpHsdZaL4NW6eVE3yjhoSDNv7HJehPZqj17kjKntAh2/p2p-circuit/p2p/12D3KooWF2P1k8SVRL1cV1Z9aNM8EVRwbrMESyRf58ceQkaht4AF')
+    expect(peerId.toString()).to.eq('12D3KooWF2P1k8SVRL1cV1Z9aNM8EVRwbrMESyRf58ceQkaht4AF')
+  })
+
+  it('can split a webrtc-direct relay addr', async () => {
+    const ma = multiaddr('/ip4/127.0.0.1/udp/9090/webrtc-direct/certhash/uEiBUr89tH2P9paTCPn-AcfVZcgvIvkwns96t4h55IpxFtA/p2p/12D3KooWB64sJqc3T3VCaubQCrfCvvfummrAA9z1vEXHJT77ZNJh/p2p-circuit/webrtc/p2p/12D3KooWFNBgv86tcpcYUHQz9FWGTrTmpMgr8feZwQXQySVTo3A7')
+
+    const { baseAddr, peerId } = splitAddr(ma)
+
+    expect(baseAddr.toString()).to.eq('/ip4/127.0.0.1/udp/9090/webrtc-direct/certhash/uEiBUr89tH2P9paTCPn-AcfVZcgvIvkwns96t4h55IpxFtA/p2p/12D3KooWB64sJqc3T3VCaubQCrfCvvfummrAA9z1vEXHJT77ZNJh/p2p-circuit/p2p/12D3KooWFNBgv86tcpcYUHQz9FWGTrTmpMgr8feZwQXQySVTo3A7')
+    expect(peerId.toString()).to.eq('12D3KooWFNBgv86tcpcYUHQz9FWGTrTmpMgr8feZwQXQySVTo3A7')
   })
 })
 


### PR DESCRIPTION
resolves #171

Dialing a peer with a multiaddr that contains both `/webrtc-direct` and `/webrtc` results in `CodeError: webrtc protocol was not present in multiaddr`. when the multiaddr is perfectly valid. For example:

`/ip4/127.0.0.1/udp/9090/webrtc-direct/certhash/uEiBUr89tH2P9paTCPn-AcfVZcgvIvkwns96t4h55IpxFtA/p2p/12D3KooWB64sJqc3T3VCaubQCrfCvvfummrAA9z1vEXHJT77ZNJh/p2p-circuit/webrtc/p2p/12D3KooWFNBgv86tcpcYUHQz9FWGTrTmpMgr8feZwQXQySVTo3A7`

