### PR TITLE
test: actually run firefox tests on firefox

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "build": "aegir build",
     "test": "aegir test -t browser",
     "test:chrome": "aegir test -t browser --cov",
-    "test:firefox": "aegir test -t browser --browser firefox",
+    "test:firefox": "aegir test -t browser -- --browser firefox",
     "lint": "aegir lint",
     "lint:fix": "aegir lint --fix",
     "clean": "aegir clean",


### PR DESCRIPTION
I noticed the `--browser` was not being passed to playwright test as a forward arg, so ensure that it's actually being run on the browser we think it is.