### PR TITLE
docs: update README.md example

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,11 +44,11 @@ Loading this module through a script tag will make it's exports available as `Li
 
 ```js
 import { createLibp2p } from 'libp2p'
-import { noise } from "@chainsafe/libp2p-noise";
+import { noise } from '@chainsafe/libp2p-noise'
 import { multiaddr } from '@multiformats/multiaddr'
-import first from "it-first";
-import { pipe } from "it-pipe";
-import { fromString, toString } from "uint8arrays";
+import first from 'it-first'
+import { pipe } from 'it-pipe'
+import { fromString, toString } from 'uint8arrays
 import { webRTC } from '@libp2p/webrtc'
 
 const node = await createLibp2p({

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Loading this module through a script tag will make it's exports available as `Li
 
 ```js
 import { createLibp2p } from 'libp2p'
-import { Noise } from '@chainsafe/libp2p-noise'
+import { noise } from "@chainsafe/libp2p-noise";
 import { multiaddr } from '@multiformats/multiaddr'
 import first from "it-first";
 import { pipe } from "it-pipe";
@@ -53,7 +53,7 @@ import { webRTC } from '@libp2p/webrtc'
 
 const node = await createLibp2p({
   transports: [webRTC()],
-  connectionEncryption: [() => new Noise()],
+  connectionEncryption: [noise()],
 });
 
 await node.start()

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ import { noise } from '@chainsafe/libp2p-noise'
 import { multiaddr } from '@multiformats/multiaddr'
 import first from 'it-first'
 import { pipe } from 'it-pipe'
-import { fromString, toString } from 'uint8arrays
+import { fromString, toString } from 'uint8arrays'
 import { webRTC } from '@libp2p/webrtc'
 
 const node = await createLibp2p({


### PR DESCRIPTION
`@chainsafe/libp2p-noise` package doesn't return `Noise` class anymore, instead is using `noice` function