### PR TITLE
fix: support lowercase transport from SDP

### DIFF
--- a/src/private-to-private/handler.ts
+++ b/src/private-to-private/handler.ts
@@ -152,5 +152,5 @@ function parseRemoteAddress (sdp: string): string {
     return '/webrtc'
   }
 
-  return `/dnsaddr/${candidateParts[4]}/${candidateParts[2]}/${candidateParts[3]}/webrtc`
+  return `/dnsaddr/${candidateParts[4]}/${candidateParts[2].toLowerCase()}/${candidateParts[3]}/webrtc`
 }


### PR DESCRIPTION
In the interop tests, we consistently get an error [parsing the "TCP" transport](https://github.com/libp2p/js-libp2p/actions/runs/5161125759/jobs/9298363455#step:7:1788). "TCP", note the uppercase, comes from the sdp string. Here's an example of Firefox dialing Firefox:

```
a=candidate:0 1 UDP 2122252543 d4d2ec50-fb17-4b38-a32a-a6f6c010c46d.local 55612 typ host
a=candidate:1 1 TCP 2105524479 d4d2ec50-fb17-4b38-a32a-a6f6c010c46d.local 9 typ host tcptype active
```

This doesn't show up for other browsers:

Chromium dialing Firefox:
```
a=candidate:0 1 udp 2122252543 ac34f294-1033-4133-8246-b0cf6eaed4aa.local 59154 typ host generation 0
a=candidate:1 1 tcp 2105524479 ac34f294-1033-4133-8246-b0cf6eaed4aa.local 9 typ host tcptype active generation 0
```

Firefox dialing Chromium:
```
a=candidate:496977973 1 udp 2113937151 19ad6c73-6b2b-44a1-b327-bbfb0725cd30.local 51868 typ host generation 0 
```


